### PR TITLE
Include orientation in the state if it is configured

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,12 @@ stat -c "%G" /dev/ttyACM0
 ```
 See [here](https://wiki.archlinux.org/title/users_and_groups#Other_examples_of_user_management) for how to add a user to a group on Linux. You may need to log out of and log in to the operating system session again. On macOS and Windows, the instructions are too varied to list here. Please research how to do this for your combination of OS and OS version.
 
+The Sora Device Client, by default, does not transmit device orientation data. However, if this flag is enabled, the client will only send the device state after receiving the `ORIENT EULER` message. It is important to note that this message is exclusively available in products with inertial fusion enabled. As such, please only enable this feature if it is required for your specific use case.
+```toml
+[location.format.sbp]
+orientation = false
+```
+
 ## Running
 
 ```

--- a/sora_device_client/cli/start.py
+++ b/sora_device_client/cli/start.py
@@ -56,7 +56,11 @@ def start() -> None:
                         if fix_mode is None or fix_mode == "Invalid":
                             logger.warn("fix_mode is %s, not sending state.", fix_mode)
                             continue
-                        client.send_state(pos=loc.position, state=loc.status)
+                        client.send_state(
+                            pos=loc.position,
+                            ori=loc.orientation,
+                            state=loc.status,
+                        )
                 except KeyboardInterrupt:
                     logger.info("Terminating state stream..")
                     client.stop(timeout=5)

--- a/sora_device_client/client/__init__.py
+++ b/sora_device_client/client/__init__.py
@@ -29,7 +29,7 @@ import sora.device.v1beta.service_pb2 as device_pb2
 from sora_device_client.config.device import DeviceConfig
 from sora_device_client.config.server import ServerConfig
 from sora_device_client.config import DATA_DIR
-from sora_device_client.location import Position
+from sora_device_client.location import Position, Orientation
 
 
 class ExitMain(Exception):
@@ -374,6 +374,7 @@ class SoraDeviceClient:
     def send_state(
         self,
         pos: Position,
+        ori: Optional[Orientation] = None,
         state: Optional[Dict[str, Any]] = None,
     ) -> None:
         state = state or {}
@@ -385,7 +386,7 @@ class SoraDeviceClient:
             # Note: this will be replaced the by the device_id claimed the JWT
             device_id=str(self.device_config.device_id),
             time=timestamp,
-            orientation=None,
+            orientation=_ori_to_pb(ori),
             pos=_pos_to_pb(pos),
             user_data=state_pb,
         )
@@ -396,3 +397,11 @@ class SoraDeviceClient:
 
 def _pos_to_pb(pos: Position) -> common_pb.Position:
     return common_pb.Position(lat=pos.lat, lon=pos.lon, alt=pos.height)
+
+
+def _ori_to_pb(ori: Optional[Orientation]) -> Optional[common_pb.Orientation]:
+    return (
+        common_pb.Orientation(pitch=ori.pitch, yaw=ori.yaw, roll=ori.roll)
+        if ori
+        else None
+    )

--- a/sora_device_client/formats/__init__.py
+++ b/sora_device_client/formats/__init__.py
@@ -30,7 +30,7 @@ class Format(ContextManager[Iterable[Location]], metaclass=ABCMeta):
 def sbp_format_from_config(config: Any, driver: "BaseDriver") -> "sbp_format.SBPFormat":
     from .sbp import SBPFormat
 
-    return SBPFormat(driver)
+    return SBPFormat(driver, config)
 
 
 FORMATS = {


### PR DESCRIPTION
As the title says, if the orientation is set to true in config.toml then we will listen to SBP_MSG_ORIENT_EULER and send it in the state. 